### PR TITLE
Check attribute types for safety

### DIFF
--- a/accessibility-sys/src/error.rs
+++ b/accessibility-sys/src/error.rs
@@ -17,3 +17,25 @@ pub const kAXErrorAPIDisabled: i32 = -25211;
 pub const kAXErrorNoValue: i32 = -25212;
 pub const kAXErrorParameterizedAttributeUnsupported: i32 = -25213;
 pub const kAXErrorNotEnoughPrecision: i32 = -25214;
+
+pub fn error_string(error: AXError) -> &'static str {
+    match error {
+        kAXErrorSuccess => "kAXErrorSuccess",
+        kAXErrorFailure => "kAXErrorFailure",
+        kAXErrorIllegalArgument => "kAXErrorIllegalArgument",
+        kAXErrorInvalidUIElement => "kAXErrorInvalidUIElement",
+        kAXErrorInvalidUIElementObserver => "kAXErrorInvalidUIElementObserver",
+        kAXErrorCannotComplete => "kAXErrorCannotComplete",
+        kAXErrorAttributeUnsupported => "kAXErrorAttributeUnsupported",
+        kAXErrorActionUnsupported => "kAXErrorActionUnsupported",
+        kAXErrorNotificationUnsupported => "kAXErrorNotificationUnsupported",
+        kAXErrorNotImplemented => "kAXErrorNotImplemented",
+        kAXErrorNotificationAlreadyRegistered => "kAXErrorNotificationAlreadyRegistered",
+        kAXErrorNotificationNotRegistered => "kAXErrorNotificationNotRegistered",
+        kAXErrorAPIDisabled => "kAXErrorAPIDisabled",
+        kAXErrorNoValue => "kAXErrorNoValue",
+        kAXErrorParameterizedAttributeUnsupported => "kAXErrorParameterizedAttributeUnsupported",
+        kAXErrorNotEnoughPrecision => "kAXErrorNotEnoughPrecision",
+        _ => "unknown error",
+    }
+}

--- a/accessibility/src/lib.rs
+++ b/accessibility/src/lib.rs
@@ -3,7 +3,7 @@ pub mod attribute;
 pub mod ui_element;
 mod util;
 
-use accessibility_sys::AXError;
+use accessibility_sys::{error_string, AXError};
 use core_foundation::{
     array::CFArray,
     base::CFTypeID,
@@ -35,7 +35,7 @@ pub enum Error {
         expected: CFTypeID,
         received: CFTypeID,
     },
-    #[error("accessibility error {0:?}")]
+    #[error("accessibility error {}", error_string(*.0))]
     Ax(AXError),
 }
 

--- a/accessibility/src/lib.rs
+++ b/accessibility/src/lib.rs
@@ -4,7 +4,12 @@ pub mod ui_element;
 mod util;
 
 use accessibility_sys::AXError;
-use core_foundation::{array::CFArray, base::TCFType, string::CFString};
+use core_foundation::{
+    array::CFArray,
+    base::CFTypeID,
+    base::{CFCopyTypeIDDescription, TCFType},
+    string::CFString,
+};
 use std::{
     cell::{Cell, RefCell},
     thread,
@@ -16,12 +21,26 @@ pub use action::*;
 pub use attribute::*;
 pub use ui_element::*;
 
+#[non_exhaustive]
 #[derive(Debug, TError)]
 pub enum Error {
     #[error("element not found")]
     NotFound,
+    #[error(
+        "expected attribute type {} but got {}",
+        type_name(*expected),
+        type_name(*received),
+    )]
+    UnexpectedType {
+        expected: CFTypeID,
+        received: CFTypeID,
+    },
     #[error("accessibility error {0:?}")]
     Ax(AXError),
+}
+
+fn type_name(type_id: CFTypeID) -> CFString {
+    unsafe { CFString::wrap_under_create_rule(CFCopyTypeIDDescription(type_id)) }
 }
 
 pub trait TreeVisitor {


### PR DESCRIPTION
It's probably not safe to assume that an application has a conforming accessibility implementation with expected types for every standard attribute, so check the type and report an error if it's incorrect.

This also marks the Error enum as `non_exhaustive` while we're adding a variant.

Finally, stringify AXErrors and report them in the Error impl. (This includes a cherry-pick from #1.)