### PR TITLE
Add support for AXValue properties

### DIFF
--- a/accessibility-sys/src/attribute_constants.rs
+++ b/accessibility-sys/src/attribute_constants.rs
@@ -20,6 +20,7 @@ pub const kAXSelectedChildrenAttribute: &str = "AXSelectedChildren";
 pub const kAXVisibleChildrenAttribute: &str = "AXVisibleChildren";
 pub const kAXWindowAttribute: &str = "AXWindow";
 pub const kAXTopLevelUIElementAttribute: &str = "AXTopLevelUIElement";
+pub const kAXFrameAttribute: &str = "AXFrame";
 pub const kAXPositionAttribute: &str = "AXPosition";
 pub const kAXSizeAttribute: &str = "AXSize";
 pub const kAXOrientationAttribute: &str = "AXOrientation";

--- a/accessibility/Cargo.toml
+++ b/accessibility/Cargo.toml
@@ -15,6 +15,7 @@ objc = "0.2"
 thiserror = "1"
 
 accessibility-sys = { path = "../accessibility-sys", version = "0.2.0" }
+core-graphics-types = "0.1.3"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/accessibility/Cargo.toml
+++ b/accessibility/Cargo.toml
@@ -10,7 +10,7 @@ description = "Bindings for macOS Accessibility services"
 
 [dependencies]
 cocoa = "0.26"
-core-foundation = "0.10"
+core-foundation = "0.10.1"
 objc = "0.2"
 thiserror = "1"
 

--- a/accessibility/src/attribute.rs
+++ b/accessibility/src/attribute.rs
@@ -1,13 +1,14 @@
 use accessibility_sys::{
     kAXAllowedValuesAttribute, kAXChildrenAttribute, kAXContentsAttribute, kAXDescriptionAttribute,
     kAXElementBusyAttribute, kAXEnabledAttribute, kAXFocusedAttribute, kAXFocusedWindowAttribute,
-    kAXFrontmostAttribute, kAXHelpAttribute, kAXIdentifierAttribute, kAXLabelValueAttribute,
-    kAXMainAttribute, kAXMainWindowAttribute, kAXMaxValueAttribute, kAXMinValueAttribute,
-    kAXMinimizedAttribute, kAXParentAttribute, kAXPlaceholderValueAttribute, kAXRoleAttribute,
-    kAXRoleDescriptionAttribute, kAXSelectedChildrenAttribute, kAXSubroleAttribute,
-    kAXTitleAttribute, kAXTitleUIElementAttribute, kAXTopLevelUIElementAttribute,
-    kAXValueAttribute, kAXValueDescriptionAttribute, kAXValueIncrementAttribute,
-    kAXVisibleChildrenAttribute, kAXWindowAttribute, kAXWindowsAttribute,
+    kAXFrameAttribute, kAXFrontmostAttribute, kAXHelpAttribute, kAXIdentifierAttribute,
+    kAXLabelValueAttribute, kAXMainAttribute, kAXMainWindowAttribute, kAXMaxValueAttribute,
+    kAXMinValueAttribute, kAXMinimizedAttribute, kAXParentAttribute, kAXPlaceholderValueAttribute,
+    kAXPositionAttribute, kAXRoleAttribute, kAXRoleDescriptionAttribute,
+    kAXSelectedChildrenAttribute, kAXSizeAttribute, kAXSubroleAttribute, kAXTitleAttribute,
+    kAXTitleUIElementAttribute, kAXTopLevelUIElementAttribute, kAXValueAttribute,
+    kAXValueDescriptionAttribute, kAXValueIncrementAttribute, kAXVisibleChildrenAttribute,
+    kAXWindowAttribute, kAXWindowsAttribute,
 };
 use core_foundation::{
     array::CFArray,
@@ -15,9 +16,10 @@ use core_foundation::{
     boolean::CFBoolean,
     string::CFString,
 };
+use core_graphics_types::geometry::{CGPoint, CGRect, CGSize};
 use std::marker::PhantomData;
 
-use crate::{AXUIElement, ElementFinder, Error};
+use crate::{value::AXValue, AXUIElement, ElementFinder, Error};
 
 pub trait TAXAttribute {
     type Value: TCFType;
@@ -37,18 +39,44 @@ impl<T> AXAttribute<T> {
     }
 }
 
+macro_rules! constructor {
+    ($name:ident, $typ:ty, $const:ident $(,$setter:ident)?) => {
+        pub fn $name() -> AXAttribute<$typ> {
+            AXAttribute(CFString::from_static_string($const), PhantomData)
+        }
+    };
+}
+
 macro_rules! accessor {
+    (@decl $name:ident, AXValue<$typ:ty>, $const:ident, $setter:ident) => {
+        accessor!(@decl $name, AXValue<$typ>, $const);
+        fn $setter(&self, value: impl Into<$typ>) -> Result<(), Error>;
+    };
     (@decl $name:ident, $typ:ty, $const:ident, $setter:ident) => {
         accessor!(@decl $name, $typ, $const);
         fn $setter(&self, value: impl Into<$typ>) -> Result<(), Error>;
     };
+    (@decl $name:ident, AXValue<$typ:ty>, $const:ident) => {
+        fn $name(&self) -> Result<$typ, Error>;
+    };
     (@decl $name:ident, $typ:ty, $const:ident) => {
         fn $name(&self) -> Result<$typ, Error>;
+    };
+    (@impl $name:ident, AXValue<$typ:ty>, $const:ident, $setter:ident) => {
+        accessor!(@impl $name, AXValue<$typ>, $const);
+        fn $setter(&self, value: impl Into<$typ>) -> Result<(), Error> {
+            self.set_attribute(&AXAttribute::$name(), AXValue::new(&value.into()).expect("wrong type"))
+        }
     };
     (@impl $name:ident, $typ:ty, $const:ident, $setter:ident) => {
         accessor!(@impl $name, $typ, $const);
         fn $setter(&self, value: impl Into<$typ>) -> Result<(), Error> {
             self.set_attribute(&AXAttribute::$name(), value)
+        }
+    };
+    (@impl $name:ident, AXValue<$typ:ty>, $const:ident) => {
+        fn $name(&self) -> Result<$typ, Error> {
+            self.attribute(&AXAttribute::$name()).map(|v| v.value().expect("wrong type"))
         }
     };
     (@impl $name:ident, $typ:ty, $const:ident) => {
@@ -59,25 +87,21 @@ macro_rules! accessor {
 }
 
 macro_rules! define_attributes {
-    ($(($name:ident, $typ:ty, $const:ident $(,$setter:ident)?)),*,) => {
+    ($(($($args:tt)*)),*,) => {
         impl AXAttribute<()> {
-            $(
-                pub fn $name() -> AXAttribute<$typ> {
-                    AXAttribute(CFString::from_static_string($const), PhantomData)
-                }
-            )*
+            $(constructor!($($args)*);)*
         }
 
         pub trait AXUIElementAttributes {
-            $(accessor!(@decl $name, $typ, $const $(, $setter)? );)*
+            $(accessor!(@decl $($args)*);)*
         }
 
         impl AXUIElementAttributes for AXUIElement {
-            $(accessor!(@impl $name, $typ, $const $(, $setter)? );)*
+            $(accessor!(@impl $($args)*);)*
         }
 
         impl AXUIElementAttributes for ElementFinder {
-            $(accessor!(@impl $name, $typ, $const $(, $setter)? );)*
+            $(accessor!(@impl $($args)*);)*
         }
     }
 }
@@ -98,6 +122,7 @@ define_attributes![
     (focused, CFBoolean, kAXFocusedAttribute),
     (focused_window, AXUIElement, kAXFocusedWindowAttribute),
     (frontmost, CFBoolean, kAXFrontmostAttribute, set_frontmost),
+    (frame, AXValue<CGRect>, kAXFrameAttribute),
     (help, CFString, kAXHelpAttribute),
     (identifier, CFString, kAXIdentifierAttribute),
     (label_value, CFString, kAXLabelValueAttribute),
@@ -108,6 +133,12 @@ define_attributes![
     (minimized, CFBoolean, kAXMinimizedAttribute),
     (parent, AXUIElement, kAXParentAttribute),
     (placeholder_value, CFString, kAXPlaceholderValueAttribute),
+    (
+        position,
+        AXValue<CGPoint>,
+        kAXPositionAttribute,
+        set_position
+    ),
     (role, CFString, kAXRoleAttribute),
     (role_description, CFString, kAXRoleDescriptionAttribute),
     (
@@ -115,6 +146,7 @@ define_attributes![
         CFArray<AXUIElement>,
         kAXSelectedChildrenAttribute
     ),
+    (size, AXValue<CGSize>, kAXSizeAttribute, set_size),
     (subrole, CFString, kAXSubroleAttribute),
     (title, CFString, kAXTitleAttribute),
     (title_ui_element, AXUIElement, kAXTitleUIElementAttribute),

--- a/accessibility/src/attribute.rs
+++ b/accessibility/src/attribute.rs
@@ -65,7 +65,7 @@ macro_rules! accessor {
     (@impl $name:ident, AXValue<$typ:ty>, $const:ident, $setter:ident) => {
         accessor!(@impl $name, AXValue<$typ>, $const);
         fn $setter(&self, value: impl Into<$typ>) -> Result<(), Error> {
-            self.set_attribute(&AXAttribute::$name(), AXValue::new(&value.into()).expect("wrong type"))
+            self.set_attribute(&AXAttribute::$name(), AXValue::new(&value.into())?)
         }
     };
     (@impl $name:ident, $typ:ty, $const:ident, $setter:ident) => {
@@ -76,7 +76,7 @@ macro_rules! accessor {
     };
     (@impl $name:ident, AXValue<$typ:ty>, $const:ident) => {
         fn $name(&self) -> Result<$typ, Error> {
-            self.attribute(&AXAttribute::$name()).map(|v| v.value().expect("wrong type"))
+            self.attribute(&AXAttribute::$name()).and_then(|v| v.value())
         }
     };
     (@impl $name:ident, $typ:ty, $const:ident) => {

--- a/accessibility/src/lib.rs
+++ b/accessibility/src/lib.rs
@@ -4,7 +4,7 @@ pub mod ui_element;
 mod util;
 pub mod value;
 
-use accessibility_sys::{error_string, AXError};
+use accessibility_sys::{error_string, AXError, AXValueType};
 use core_foundation::{
     array::CFArray,
     base::CFTypeID,
@@ -35,6 +35,15 @@ pub enum Error {
     UnexpectedType {
         expected: CFTypeID,
         received: CFTypeID,
+    },
+    #[error(
+        "expected attribute value type {} but got {}",
+        value::value_type_name(*expected),
+        value::value_type_name(*received),
+    )]
+    UnexpectedValueType {
+        expected: AXValueType,
+        received: AXValueType,
     },
     #[error("accessibility error {}", error_string(*.0))]
     Ax(AXError),

--- a/accessibility/src/lib.rs
+++ b/accessibility/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod attribute;
 pub mod ui_element;
 mod util;
+pub mod value;
 
 use accessibility_sys::{error_string, AXError};
 use core_foundation::{

--- a/accessibility/src/value.rs
+++ b/accessibility/src/value.rs
@@ -1,13 +1,14 @@
 use std::{ffi::c_void, marker::PhantomData};
 
 use accessibility_sys::{
-    kAXErrorFailure, kAXErrorSuccess, kAXValueTypeCFRange, kAXValueTypeCGPoint, kAXValueTypeCGRect,
-    kAXValueTypeCGSize, AXValueCreate, AXValueGetTypeID, AXValueGetValue, AXValueRef, AXValueType,
+    kAXErrorFailure, kAXErrorSuccess, kAXValueTypeAXError, kAXValueTypeCFRange,
+    kAXValueTypeCGPoint, kAXValueTypeCGRect, kAXValueTypeCGSize, kAXValueTypeIllegal,
+    AXValueCreate, AXValueGetType, AXValueGetTypeID, AXValueGetValue, AXValueRef, AXValueType,
 };
 use core_foundation::{base::CFRange, declare_TCFType, impl_CFTypeDescription, impl_TCFType};
 use core_graphics_types::geometry::{CGPoint, CGRect, CGSize};
 
-use crate::util::ax_call;
+use crate::{util::ax_call, Error};
 
 pub trait AXValueKind {
     const TYPE: AXValueType;
@@ -26,24 +27,31 @@ impl AXValueKind for CFRange {
     const TYPE: AXValueType = kAXValueTypeCFRange;
 }
 
+pub(crate) fn value_type_name(kind: AXValueType) -> &'static str {
+    #[allow(non_upper_case_globals)]
+    match kind {
+        kAXValueTypeCGPoint => "CGPoint",
+        kAXValueTypeCGSize => "CGSize",
+        kAXValueTypeCGRect => "CGRect",
+        kAXValueTypeCFRange => "CFRange",
+        kAXValueTypeAXError => "AXError",
+        kAXValueTypeIllegal => "Illegal",
+        _ => "<unknown>",
+    }
+}
+
 declare_TCFType!(AXValue<T: AXValueKind>, AXValueRef);
 impl_TCFType!(AXValue<T: AXValueKind>, AXValueRef, AXValueGetTypeID);
 impl_CFTypeDescription!(AXValue<T: AXValueKind>);
 
-#[derive(Copy, Clone, Debug)]
-pub struct WrongType;
-
 impl<T: AXValueKind> AXValue<T> {
-    pub fn new(val: &T) -> Result<Self, WrongType> {
+    pub fn new(val: &T) -> Result<Self, Error> {
         let ptr = unsafe { AXValueCreate(T::TYPE, val as *const T as *const c_void) };
-        if ptr.is_null() {
-            Err(WrongType)
-        } else {
-            Ok(Self(ptr, PhantomData))
-        }
+        assert!(!ptr.is_null());
+        Ok(Self(ptr, PhantomData))
     }
 
-    pub fn value(&self) -> Result<T, WrongType> {
+    pub fn value(&self) -> Result<T, Error> {
         unsafe {
             ax_call(
                 |x: *mut T| match AXValueGetValue(self.0, T::TYPE, x as *mut _) {
@@ -51,7 +59,10 @@ impl<T: AXValueKind> AXValue<T> {
                     false => kAXErrorFailure,
                 },
             )
-            .map_err(|_| WrongType)
+            .map_err(|_| Error::UnexpectedValueType {
+                expected: T::TYPE,
+                received: AXValueGetType(self.0),
+            })
         }
     }
 }

--- a/accessibility/src/value.rs
+++ b/accessibility/src/value.rs
@@ -1,0 +1,57 @@
+use std::{ffi::c_void, marker::PhantomData};
+
+use accessibility_sys::{
+    kAXErrorFailure, kAXErrorSuccess, kAXValueTypeCFRange, kAXValueTypeCGPoint, kAXValueTypeCGRect,
+    kAXValueTypeCGSize, AXValueCreate, AXValueGetTypeID, AXValueGetValue, AXValueRef, AXValueType,
+};
+use core_foundation::{base::CFRange, declare_TCFType, impl_CFTypeDescription, impl_TCFType};
+use core_graphics_types::geometry::{CGPoint, CGRect, CGSize};
+
+use crate::util::ax_call;
+
+pub trait AXValueKind {
+    const TYPE: AXValueType;
+}
+
+impl AXValueKind for CGPoint {
+    const TYPE: AXValueType = kAXValueTypeCGPoint;
+}
+impl AXValueKind for CGSize {
+    const TYPE: AXValueType = kAXValueTypeCGSize;
+}
+impl AXValueKind for CGRect {
+    const TYPE: AXValueType = kAXValueTypeCGRect;
+}
+impl AXValueKind for CFRange {
+    const TYPE: AXValueType = kAXValueTypeCFRange;
+}
+
+declare_TCFType!(AXValue<T: AXValueKind>, AXValueRef);
+impl_TCFType!(AXValue<T: AXValueKind>, AXValueRef, AXValueGetTypeID);
+impl_CFTypeDescription!(AXValue<T: AXValueKind>);
+
+#[derive(Copy, Clone, Debug)]
+pub struct WrongType;
+
+impl<T: AXValueKind> AXValue<T> {
+    pub fn new(val: &T) -> Result<Self, WrongType> {
+        let ptr = unsafe { AXValueCreate(T::TYPE, val as *const T as *const c_void) };
+        if ptr.is_null() {
+            Err(WrongType)
+        } else {
+            Ok(Self(ptr, PhantomData))
+        }
+    }
+
+    pub fn value(&self) -> Result<T, WrongType> {
+        unsafe {
+            ax_call(
+                |x: *mut T| match AXValueGetValue(self.0, T::TYPE, x as *mut _) {
+                    true => kAXErrorSuccess,
+                    false => kAXErrorFailure,
+                },
+            )
+            .map_err(|_| WrongType)
+        }
+    }
+}

--- a/aq/Cargo.toml
+++ b/aq/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/eiz/accessibility"
 description = "Accessibility query"
 
 [dependencies]
-core-foundation = "0.10"
+core-foundation = "0.10.1"
 structopt = "0.3"
 
 accessibility = { path = "../accessibility", version = "0.2.0" }


### PR DESCRIPTION
Seeking feedback on this approach. `AXValue<T>` is based on the way `AXAttribute<T>` works.

I have been using this API and personally am pretty happy with it. Unfortunately the implementation depends on https://github.com/servo/core-foundation-rs/pull/652 which is still awaiting review, so I'm marking this PR as a draft in the meantime.