### PR TITLE
Fix a panic in aq and add a new attribute

### DIFF
--- a/accessibility/src/attribute.rs
+++ b/accessibility/src/attribute.rs
@@ -5,9 +5,9 @@ use accessibility_sys::{
     kAXMainAttribute, kAXMainWindowAttribute, kAXMaxValueAttribute, kAXMinValueAttribute,
     kAXMinimizedAttribute, kAXParentAttribute, kAXPlaceholderValueAttribute, kAXRoleAttribute,
     kAXRoleDescriptionAttribute, kAXSelectedChildrenAttribute, kAXSubroleAttribute,
-    kAXTitleAttribute, kAXTopLevelUIElementAttribute, kAXValueAttribute,
-    kAXValueDescriptionAttribute, kAXValueIncrementAttribute, kAXVisibleChildrenAttribute,
-    kAXWindowAttribute, kAXWindowsAttribute,
+    kAXTitleAttribute, kAXTitleUIElementAttribute, kAXTopLevelUIElementAttribute,
+    kAXValueAttribute, kAXValueDescriptionAttribute, kAXValueIncrementAttribute,
+    kAXVisibleChildrenAttribute, kAXWindowAttribute, kAXWindowsAttribute,
 };
 use core_foundation::{
     array::CFArray,
@@ -117,6 +117,7 @@ define_attributes![
     ),
     (subrole, CFString, kAXSubroleAttribute),
     (title, CFString, kAXTitleAttribute),
+    (title_ui_element, AXUIElement, kAXTitleUIElementAttribute),
     (
         top_level_ui_element,
         AXUIElement,

--- a/aq/src/main.rs
+++ b/aq/src/main.rs
@@ -31,7 +31,7 @@ impl TreeVisitor for PrintyBoi {
             "{}- {} ({} children)",
             indent,
             role,
-            element.children().unwrap().len()
+            element.children().map(|c| c.len()).unwrap_or_default()
         ];
 
         if let Ok(names) = element.attribute_names() {


### PR DESCRIPTION
Hey, sometimes `AXUIElement.children` can be `None` which is unwrapped. You can reproduce it by running aq on System Settings.

Also add `title_ui_element`, which is useful for looking up `AXSwitch` by its associated label.