### PR TITLE
Bump core-graphics-types dep and update version

### DIFF
--- a/accessibility/Cargo.toml
+++ b/accessibility/Cargo.toml
@@ -15,7 +15,7 @@ objc = "0.2"
 thiserror = "1"
 
 accessibility-sys = { path = "../accessibility-sys", version = "0.2.0" }
-core-graphics-types = "0.1.3"
+core-graphics-types = "0.2.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/accessibility/Cargo.toml
+++ b/accessibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accessibility"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Mack Straight <mack@discordapp.com>"]
 edition = "2018"
 license = "MIT / Apache-2.0"

--- a/aq/Cargo.toml
+++ b/aq/Cargo.toml
@@ -12,4 +12,4 @@ description = "Accessibility query"
 core-foundation = "0.10.1"
 structopt = "0.3"
 
-accessibility = { path = "../accessibility", version = "0.2.0" }
+accessibility = { path = "../accessibility", version = "0.3.0" }


### PR DESCRIPTION
- **Bump core-graphics-types to 0.2.0**
- **Bump accessibility to 0.3.0**

Only the accessibility crate needs a version bump, as that is the one that depends on (and re-exports) core-graphics-types. This is a breaking change that would be noticed by existing dependents, but it should make anyone's lives easier who happens to be using the latest set of these crates.

Back in https://github.com/eiz/accessibility/pull/5#issuecomment-2921293498 I expressed a preference for keeping compatibility with the old types, but offering both options is nicer. You could also decide not to release this and jump straight to objc2 (#12) in the next release.